### PR TITLE
explicitly set the build-id to linker for lower version gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 #################################################################
 #
 CFLAGS := -Wall -O3 -flto -g -DFP_RELAX=0 #-DDEBUG
-THE_CFLAGS := $(CFLAGS) -fPIC -MMD -fvisibility=hidden
+THE_CFLAGS := $(CFLAGS) -fPIC -Wl,--build-id -MMD -fvisibility=hidden
 
 #################################################################
 #

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ endif
 CFLAGS := -Wall -O3 -flto -g -DFP_RELAX=0 #-DDEBUG
 THE_CFLAGS := $(CFLAGS) -fPIC -Wl,--build-id -MMD -fvisibility=hidden
 
+ifeq ($(OS), Linux)
+    THE_CFLAGS := $(THE_CFLAGS) -Wl,--build-id
+endif
+
 #################################################################
 #
 #       Installtion flags


### PR DESCRIPTION
I'm using the gcc 4.8.0 on Centos 6 to build the rpm package. It's strange that the default i cannot get the build-id by `objdump -s -j .note.gnu.build-id libljson.so` with `gcc -fPIC`, so we have to explicitly set the build-id when compile the shared library.