### PR TITLE
Fix out-of-bounds read in debug dump_obj function

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -485,11 +485,11 @@ dump_obj(FILE* f, obj_t* obj) {
     if (type <= OT_LAST_PRIMITIVE) {
         dump_primitive_obj(f, obj);
         fputc('\n', f);
-    }
-
-    obj_composite_t* cobj = (obj_composite_t*)(void*)obj;
-    for (; cobj; cobj = cobj->reverse_nesting_order) {
-        dump_composite_obj(f, cobj);
+    } else {
+        obj_composite_t* cobj = (obj_composite_t*)(void*)obj;
+        for (; cobj; cobj = cobj->reverse_nesting_order) {
+            dump_composite_obj(f, cobj);
+        }
     }
 }
 


### PR DESCRIPTION
The read of `reverse_nesting_order` was unconditional regardless of whether the object was really a composite object or not.